### PR TITLE
[課題41] TerraformへのGitHub Actionsの実装

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,48 @@
+name: Terraform CI/CD
+run-name: Deploy by Terraform
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'lecture33/**/*.tf'
+      - 'lecture33/modules/**/*tftest.hcl'
+      - '.github/workflows/*.yml'
+  pull_request:
+    paths:
+      - 'lecture33/**/*.tf'
+      - 'lecture33/modules/**/*tftest.hcl'
+      - '.github/workflows/*.yml'
+
+jobs:
+  terraform_deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ap-northeast-1
+    
+    defaults:
+      run:
+        working-directory: lecture33
+  
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: init
+        run: terraform init
+
+      - name: Validate
+        run: terraform validate
+
+      - name: plan
+        run: terraform plan
+
+      - name: apply
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: terraform apply -auto-approve


### PR DESCRIPTION
## 実装内容
- 課題33で作成したTerraformへのGitHub Actionsの実装

## 工夫した点・学んだこと
- フォルダを置く場所を勘違いしていた。Terraformフォルダのみ見ており、GitHub直下に設定しているつもりになっていたので、どのフォルダに配置しているか今後確認を行なう。
- ドキュメントを読むのにまだ慣れないが、前よりは抵抗なく読むようになった。
- 拡張子違いで動かなかったので、自身で表記を統一する