### PR TITLE
[課題42]AnsibleでのEC2へのJavaインストール

### DIFF
--- a/.github/workflows/Ansible.yml
+++ b/.github/workflows/Ansible.yml
@@ -1,0 +1,29 @@
+name: Ansible_lecture42
+run-name: install Java
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/Ansible.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/Ansible.yml'
+
+jobs:  
+  Ansible:
+    runs-on: ubuntu-latest
+
+    # env:
+    #   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #   AWS_DEFAULT_REGION: ap-northeast-1
+
+    # defaults:
+    #   run:
+    #     working-directory: ./Ansible
+  
+    steps:
+      - uses: actions/checkout@v4
+

--- a/.github/workflows/Ansible.yml
+++ b/.github/workflows/Ansible.yml
@@ -7,23 +7,71 @@ on:
       - main
     paths:
       - '.github/workflows/Ansible.yml'
+      - 'Ansible/playbook.yml'
+      - 'Ansible/inventory.ini'
   pull_request:
     paths:
       - '.github/workflows/Ansible.yml'
+      - 'Ansible/playbook.yml'
+      - 'Ansible/inventory.ini'
 
 jobs:  
-  Ansible:
+  Ansible_java_test:
     runs-on: ubuntu-latest
 
-    # env:
-    #   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #   AWS_DEFAULT_REGION: ap-northeast-1
+    defaults:
+      run:
+        working-directory: ./Ansible
 
-    # defaults:
-    #   run:
-    #     working-directory: ./Ansible
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ap-northeast-1
+      ANSIBLE_HOST_KEY_CHECKING: "False"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Ansible
+        run: sudo apt install ansible -y
+
+      - name: Set up SSH key
+        run: |
+          echo "${{ secrets.EC2_SSH_KEY }}" > private_key.pem
+          chmod 600 private_key.pem
+
+      - name: Syntax check
+        run: ansible-playbook --syntax-check -i inventory.ini playbook.yml 
+
+      - name: Dry run
+        run: ansible-playbook --check -i inventory.ini playbook.yml
+
+
+
+  Ansible_java_apply:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    defaults:
+      run:
+        working-directory: ./Ansible
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ap-northeast-1
+      ANSIBLE_HOST_KEY_CHECKING: "False"
   
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Ansible
+        run: sudo apt install ansible -y
+
+      - name: Set up SSH key
+        run: |
+          echo "${{ secrets.EC2_SSH_KEY }}" > private_key.pem
+          chmod 600 private_key.pem
+
+      - name: Apply
+        run: ansible-playbook -i inventory.ini playbook.yml

--- a/Ansible/inventory.ini
+++ b/Ansible/inventory.ini
@@ -1,0 +1,2 @@
+[myhosts]
+1.2.3.4 ansible_user=ec2-user ansible_ssh_private_key_file=~/.ssh/id_rsa

--- a/Ansible/inventory.ini
+++ b/Ansible/inventory.ini
@@ -1,2 +1,2 @@
 [myhosts]
-1.2.3.4 ansible_user=ec2-user ansible_ssh_private_key_file=~/.ssh/id_rsa
+18.181.179.28 ansible_user=ec2-user ansible_ssh_private_key_file=private_key.pem

--- a/Ansible/playbook.yml
+++ b/Ansible/playbook.yml
@@ -1,0 +1,9 @@
+- name: install Java
+  hosts: myhosts
+  become: true
+
+  tasks:
+   - name: install java-11-amazon-corretto-devel
+     ansible.builtin.dnf:
+       name: java-11-amazon-corretto-devel
+       state: present


### PR DESCRIPTION
# 実装内容
- Ansibleを用いてEC2へJavaをインストール
- 実装環境にGitHub Actionsを利用

# 工夫した点・学んだこと
- TerraformでもGitHub Actionsを用いていたので想像よりも早くできた。
- 設定する際に何を記述するべきかがまとまっていないので調べることに時間がかかるが、似た構造のブログから必要な部分を抽出して書くことが出来た